### PR TITLE
considering transaction cost when calculate available_amount

### DIFF
--- a/finrl/env/env_stocktrading.py
+++ b/finrl/env/env_stocktrading.py
@@ -132,7 +132,7 @@ class StockTradingEnv(gym.Env):
         def _do_buy():
             if self.state[index+1]>0: 
                 #Buy only if the price is > 0 (no missing data in this particular date)       
-                available_amount = self.state[0] // self.state[index+1]
+                available_amount = self.state[0] // ((self.state[index+1])*(1+ self.buy_cost_pct))
                 # print('available_amount:{}'.format(available_amount))
                 
                 #update balance


### PR DESCRIPTION
I believe it may help agent avoid getting negative asset when agent cannot afford transaction cost in the extreme